### PR TITLE
Fix footer!

### DIFF
--- a/app/assets/stylesheets/components/footer.scss
+++ b/app/assets/stylesheets/components/footer.scss
@@ -1,0 +1,11 @@
+body {
+	    display: flex;
+	        min-height: 100vh;
+	            flex-direction: column;
+
+}
+
+main {
+	    flex: 1 0 auto;
+
+}

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -24,7 +24,9 @@
 			<% end %>
 		</div>
 
+		<main role="main">
 		<%= yield %>
+		</main>
 		<%= render "layouts/footer" %>
 
 		<!-- Javascript -->


### PR DESCRIPTION
Footer now works as it should! Implemented a sticky footer.
Problem was a missing html tag (main). Check the note on the materialize page about footers:
"Note: We use flexbox to structure our html so that the footer is always on the bottom of the page. It is important to keep the structure of your page within the 3 HTML5 tags: header, main, footer"

Added a main tag to the application layout, with a aria role so it won't break in IE. A new stylesheet was also created with the css for the footer.