### PR TITLE
Sign-in now has a lighter color on navbar

### DIFF
--- a/app/views/layouts/_navbar.erb
+++ b/app/views/layouts/_navbar.erb
@@ -3,7 +3,6 @@
 	<% if signed_in? %>
 		<!-- <li><%= current_user.email %></li> -->
 		<li><%= link_to 'Edit Profile', edit_user_path(current_user) %></li>
-		<li><a href="#!">Settings</a></li>
 		<li class="divider"></li>
 		<li>
 			<%= link_to 'Sign out', sign_out_path, method: :delete %>
@@ -29,7 +28,7 @@
 			<% end %>
 			<% if !signed_in? %>
 				<li>
-					<%= link_to 'Sign in', sign_in_path %>
+					<%= link_to 'Sign in', sign_in_path, class:"teal lighten-1" %>
 				<% end %>
 				</li>
 		</ul>


### PR DESCRIPTION
So that the call-to-action is more noticeable...

<img width="1267" alt="screen shot 2015-08-04 at 17 17 21" src="https://cloud.githubusercontent.com/assets/12384305/9065939/b5ec7cde-3acc-11e5-9667-f6aecde9e372.png">

Also removed one of the options from the navbar dropdown menu, as it was going nowhere.