### PR TITLE
Fix delete chapter bug

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -43,7 +43,6 @@ gem 'cancancan'
 
 gem 'rails-i18n'
 
-gem 'responders'
 
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console

--- a/app/assets/javascripts/our.js
+++ b/app/assets/javascripts/our.js
@@ -6,7 +6,7 @@ $(document).ready(function() {
 	$(".button-collapse").sideNav();
 
 	// Prevent default action on action links inside collapsible
-	$(".inner-action").on("click", function(event) {
+	$(".inner-action").delegate("a", "click", function(event) {
 		event.stopPropagation();
 	});
 

--- a/app/assets/javascripts/our.js
+++ b/app/assets/javascripts/our.js
@@ -6,7 +6,7 @@ $(document).ready(function() {
 	$(".button-collapse").sideNav();
 
 	// Prevent default action on action links inside collapsible
-	$(".inner-action").delegate("a", "click", function(event) {
+	$(".inner-action").on("click", "a", function(event) {
 		event.stopPropagation();
 	});
 


### PR DESCRIPTION
Ignore the first commit. The second commit is the right way to fix the bug.
First commit was using the delegate function, but as of jQuery 1.7
the new recommended syntax is on.
Check this stackoverflow to find out more:
https://stackoverflow.com/questions/8325506/javascript-stoppropagation-doest-work-with-ajax-load

Bug that prevented deleting a chapter should now be fixed