### PR TITLE
Removes Buy link from Teachers

### DIFF
--- a/app/views/courses/index.html.erb
+++ b/app/views/courses/index.html.erb
@@ -29,7 +29,9 @@
 									method: :delete,
 									data: { confirm: 'Do you really want to delete?' } %>
 								<% end %>
+								<% if can? :buy, course %>
 									<%= link_to'Buy', new_course_payment_path(course.id) %>
+								<% end %>	
 						</div>
 						</div>
 					</div>


### PR DESCRIPTION
If you're a student, you get the "buy course" link, if you're not, you don't.